### PR TITLE
Python 2.6 compatibility and asset inclusion when installing as a package

### DIFF
--- a/pypicache/cache.py
+++ b/pypicache/cache.py
@@ -50,17 +50,17 @@ class PackageCache(object):
             "failed": [],
         }
         for line in (line.strip() for line in requirements_fp):
-            self.log.debug("Examining requirement {!r}".format(line))
+            self.log.debug("Examining requirement {0!r}".format(line))
             if "==" in line:
                 package, version = line.split("==")
                 try:
                     for url in (url for url in self.pypi.get_urls(package, version) if url["packagetype"] == "sdist"):
-                        self.log.debug("Looking at {!r}".format(url))
+                        self.log.debug("Looking at {0!r}".format(url))
                         self.get_file(package, url["filename"])
                         processing_info["cached"].append(url["filename"])
                 except exceptions.NotFound:
                     processing_info["failed"].append(line)
             else:
-                self.log.debug("Don't know how to handle {!r}".format(line))
+                self.log.debug("Don't know how to handle {0!r}".format(line))
                 processing_info["unparseable"].append(line)
         return processing_info

--- a/pypicache/disk.py
+++ b/pypicache/disk.py
@@ -16,15 +16,15 @@ class DiskPackageStore(object):
 
     def get_file_path(self, package, filename):
         firstletter = package[0]
-        return os.path.join(self.prefix, "packages/{}/{}/{}".format(firstletter, package, filename))
+        return os.path.join(self.prefix, "packages/{0}/{1}/{2}".format(firstletter, package, filename))
 
     def list_files(self, package):
         firstletter = package[0]
-        prefix = os.path.join(self.prefix, "packages/{}/{}".format(firstletter, package))
-        self.log.debug("Using package prefix {!r}".format(prefix))
+        prefix = os.path.join(self.prefix, "packages/{0}/{1}".format(firstletter, package))
+        self.log.debug("Using package prefix {0!r}".format(prefix))
         # Try fishing for correct name
         if not os.path.isdir(prefix):
-            self.log.info("Fishing for package matching {}".format(package))
+            self.log.info("Fishing for package matching {0}".format(package))
             g = None
             for my_package in self.list_packages():
                 if my_package.lower() == package.lower():
@@ -35,7 +35,7 @@ class DiskPackageStore(object):
                     yield i
                 return
         for root, dirs, files in os.walk(prefix, topdown=False):
-            self.log.info("Examining {} for files".format((root, dirs, files)))
+            self.log.info("Examining {0} for files".format((root, dirs, files)))
             for filename in files:
                 abspath = os.path.join(root, filename)
                 yield dict(
@@ -47,7 +47,7 @@ class DiskPackageStore(object):
 
     def list_packages(self):
         path = os.path.join(self.prefix, "packages/?/*")
-        self.log.info("Listing packages in {}".format(path))
+        self.log.info("Listing packages in {0}".format(path))
         for packagename in sorted(glob(path)):
             if not os.path.isdir(packagename):
                 continue
@@ -58,7 +58,7 @@ class DiskPackageStore(object):
         try:
             return open(path, "rb")
         except IOError:
-            self.log.info("Fishing for package file matching {}: {}".format(package, filename))
+            self.log.info("Fishing for package file matching {0}: {1}".format(package, filename))
             # Try fishing for the file with different cases
             for my_package in self.list_packages():
                 if package.lower() == my_package.lower():
@@ -66,15 +66,15 @@ class DiskPackageStore(object):
                         my_filename = fileinfo["filename"]
                         if my_filename.lower() == filename.lower():
                             return self.get_file(my_package, my_filename)
-            raise exceptions.NotFound("Package {}: {} not found in {}".format(package, filename, path))
+            raise exceptions.NotFound("Package {0}: {1} not found in {2}".format(package, filename, path))
 
     def add_file(self, package, filename, content):
         path = self.get_file_path(package, filename)
         if os.path.isfile(path):
-            raise exceptions.NotOverwritingError("Not overwriting {}".format(path))
+            raise exceptions.NotOverwritingError("Not overwriting {0}".format(path))
         prefix = os.path.dirname(path)
         if not os.path.isdir(prefix):
-            self.log.debug("Making directories {}".format(prefix))
+            self.log.debug("Making directories {0}".format(prefix))
             os.makedirs(prefix)
         with open(path, "wb") as output:
             # TODO this is working around a difference in file obj vs string somewhere

--- a/pypicache/main.py
+++ b/pypicache/main.py
@@ -26,8 +26,8 @@ def main():
         format="%(asctime)s [%(levelname)s] [%(processName)s-%(threadName)s] [%(name)s] [%(filename)s:%(lineno)d] %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S%z"
     )
-    logging.info("Debugging: {!r}".format(args.debug))
-    logging.info("Reloading: {!r}".format(args.reload))
+    logging.info("Debugging: {0!r}".format(args.debug))
+    logging.info("Reloading: {0!r}".format(args.reload))
 
     pypi_server = pypi.PyPI()
     package_store = disk.DiskPackageStore(args.prefix)

--- a/pypicache/main.py
+++ b/pypicache/main.py
@@ -13,7 +13,7 @@ def main():
     )
     parser.add_argument("prefix", help="Package prefix, e.g. /tmp/packages")
     parser.add_argument("--address", default="0.0.0.0", help="Address to bind to.")
-    parser.add_argument("--port", default=8080, help="Port to listent on.")
+    parser.add_argument("--port", default=8080, type=int, help="Port to listen on.")
     parser.add_argument("--debug", default=False, action="store_true", help="Turn on debugging logging and output.")
     parser.add_argument("--reload", default=False, action="store_true", help="Turn on automatic reloading on code changes.")
     parser.add_argument("--processes", default=1, type=int, help="Number of processes to run")

--- a/pypicache/pypi.py
+++ b/pypicache/pypi.py
@@ -24,9 +24,9 @@ def get_uri(uri):
     """
     response = requests.get(uri)
     if response.status_code == 404:
-        raise exceptions.NotFound("Can't locate {}: {}".format(uri, response))
+        raise exceptions.NotFound("Can't locate {0}: {1}".format(uri, response))
     elif response.status_code != 200:
-        raise exceptions.RemoteError("Unexpected response from {}: {}".format(uri, response))
+        raise exceptions.RemoteError("Unexpected response from {0}: {1}".format(uri, response))
     return response
 
 class PyPI(object):
@@ -39,7 +39,7 @@ class PyPI(object):
             pypi_server = pypi_server + "/"
         self.pypi_server = pypi_server
         # Certain operations aren't available via the JSON api (well, at least obviously)
-        self.xmlrpc_client = xmlrpclib.ServerProxy("{}pypi".format(self.pypi_server))
+        self.xmlrpc_client = xmlrpclib.ServerProxy("{0}pypi".format(self.pypi_server))
 
     def get_versions(self, package, show_hidden=False):
         """Returns a list of available versions for a package
@@ -53,7 +53,7 @@ class PyPI(object):
 
         """
         versions = self.xmlrpc_client.package_releases(package, show_hidden)
-        self.log.debug("Got versions {} for package {!r}".format(versions, package))
+        self.log.debug("Got versions {0} for package {1!r}".format(versions, package))
         return versions
 
     def get_urls(self, package, version):
@@ -70,26 +70,26 @@ class PyPI(object):
             package=package,
             version=version,
         )
-        self.log.info("Fetching JSON info from {}".format(uri))
+        self.log.info("Fetching JSON info from {0}".format(uri))
         r = get_uri(uri)
         for url in json.loads(r.content)["urls"]:
             yield url
 
     def get_simple_package_info(self, package):
-        uri = "{}simple/{}/".format(self.pypi_server, package)
+        uri = "{0}simple/{1}/".format(self.pypi_server, package)
         r = get_uri(uri)
         return r.content
         # TODO WIP in progress, trying to reproduce a simple page with links only
         # Better still to rewrite using local urls
-        # self.log.info("Checking PyPI for links to {}".format(package))
+        # self.log.info("Checking PyPI for links to {0}".format(package))
         # links = []
         # for version in self.pypi_get_versions(package):
-        #     self.log.debug("Found package {} version {}".format(package, version))
+        #     self.log.debug("Found package {0} version {1}".format(package, version))
         #     for url in self.pypi_get_sdist_urls(package, version):
-        #         self.log.debug("Found link {!r}".format(url))
+        #         self.log.debug("Found link {0!r}".format(url))
         #         links.append("""<a href="{url}#md5={md5_digest}">{filename}</a>""".format(**url))
 
-        # self.log.debug("Found links {}".format(links))
+        # self.log.debug("Found links {0}".format(links))
         # return SIMPLE_PACKAGE_PAGE_TEMPLATE.format(package=package, links="\n".join(links))
 
     def get_file(self, package, filename, python_version=None):
@@ -99,9 +99,9 @@ class PyPI(object):
 
         """
         if python_version is not None:
-            uri = "{}packages/{}/{}/{}/{}".format(self.pypi_server, python_version, package[0], package, filename)
+            uri = "{0}packages/{1}/{2}/{3}/{4}".format(self.pypi_server, python_version, package[0], package, filename)
         else:
-            uri = "{}packages/source/{}/{}/{}".format(self.pypi_server, package[0], package, filename)
-        self.log.debug("Fetching from {}".format(uri))
+            uri = "{0}packages/source/{1}/{2}/{3}".format(self.pypi_server, package[0], package, filename)
+        self.log.debug("Fetching from {0}".format(uri))
         r = get_uri(uri)
         return r.content

--- a/pypicache/server.py
+++ b/pypicache/server.py
@@ -59,13 +59,13 @@ def local_simple_package_info(package):
 @app.route("/packages/<python_version>/<firstletter>/<package>/<filename>", methods=["GET"])
 @app.route("/packages/source/<firstletter>/<package>/<filename>", methods=["GET"])
 def get_file(package, filename, python_version=None, firstletter=None):
-    logging.debug("Request to get package with: {} {} {} {}".format(firstletter, package, filename, python_version))
+    logging.debug("Request to get package with: {0} {1} {2} {3}".format(firstletter, package, filename, python_version))
     try:
         response = make_response(app.config["cache"].get_file(package, filename, python_version=python_version))
         content_type, _ = mimetypes.guess_type(filename)
         if content_type is None and filename.endswith(".egg"):
             content_type = "application/zip"
-        logging.debug("Setting mime type of {!r} to {!r}".format(filename, content_type))
+        logging.debug("Setting mime type of {0!r} to {1!r}".format(filename, content_type))
         response.content_type = content_type
         return response
     except exceptions.NotFound:
@@ -99,7 +99,7 @@ def post_uploadpackage():
         return response
     filename = request.files["package"].filename
     package = re.match(r"(?P<package>.*?)-.*?\..*", filename).groupdict()["package"]
-    logging.debug("Parsed {!r} out of {!r}".format(package, filename))
+    logging.debug("Parsed {0!r} out of {1!r}".format(package, filename))
     app.config["package_store"].add_file(package, filename, request.files["package"].stream)
     return jsonify({"uploaded": "ok"})
 

--- a/setup.py
+++ b/setup.py
@@ -8,4 +8,10 @@ setup(
     author_email='mick@twomeylee.name',
     url='http://readthedocs.org/projects/pypicache/',
     packages=['pypicache'],
+    package_data={
+        'pypicache': [
+            'static/*/*',
+            'templates/*.html',
+        ]
+    }
 )

--- a/tests/integration_server.py
+++ b/tests/integration_server.py
@@ -17,7 +17,7 @@ class ServerIntegrationTestCase(unittest.TestCase):
         cls.cache_folder = tempfile.mkdtemp("pypicache")
         # This assumes this port is free
         cmd = ["python", "-m", "pypicache.main", "--address", "127.0.0.1", "--port", "8484", cls.cache_folder]
-        cls.log.info("Starting {}".format(cmd))
+        cls.log.info("Starting {0}".format(cmd))
         cls.server_process = subprocess.Popen(cmd)
         # TODO blech, need to know it's started
         time.sleep(5)
@@ -30,10 +30,10 @@ class ServerIntegrationTestCase(unittest.TestCase):
         cls.server_process.wait()
 
     def get(self, path, expected=200):
-        uri = "http://127.0.0.1:8484{}".format(path)
-        self.log.debug("Fetching: {}".format(uri))
+        uri = "http://127.0.0.1:8484{0}".format(path)
+        self.log.debug("Fetching: {0}".format(uri))
         response = requests.get(uri)
-        self.log.debug("Got response: {}".format(response))
+        self.log.debug("Got response: {0}".format(response))
         self.assertEqual(response.status_code, expected)
 
     def test_index(self):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,7 +51,7 @@ class ServerTestCase(unittest.TestCase):
             "/packages/source/M/MyPackage/MyPackage-1.0.tar.gz",
             "/packages/MyPackage/MyPackage-1.0.tar.gz",
         ]:
-            logging.info("Testing url {}".format(url))
+            logging.info("Testing url {0}".format(url))
             self.mock_packagecache.get_file.return_value = "--package-data--"
             response = self.app.get(url)
             self.assertEqual("application/x-tar", response.headers["Content-Type"])


### PR DESCRIPTION
A few quick fixes I needed on a production deployment of pypicache, mostly trivial.

Firstly, because recent versions of Debian are still stuck on Python 2.6.6, I needed to add positional argument specifiers.

Secondly, because we need to install everything as a package, I had to include the package data locations in the setup.py file. Unfortunately specifying them in the manifest isn't enough unless you're deploying into a virtual environment using 'python setup.py develop' or the like. That includes them in the distribution tarball, but they won't be installed.
